### PR TITLE
Ensure pubkey is correctly constructed

### DIFF
--- a/pkg/picocert/picocert.go
+++ b/pkg/picocert/picocert.go
@@ -137,8 +137,10 @@ func Issue(issuer *CertificateWithKey, subject string, validFrom, validTo uint64
 		return nil, err
 	}
 
-	pub := append([]byte{0x04}, priv.PublicKey.X.Bytes()...)
-	pub = append(pub, priv.PublicKey.Y.Bytes()...)
+	// Ensure x, y are exactly 32 bytes when constructing the pubkey
+	xBytes := priv.PublicKey.X.FillBytes(make([]byte, 32))
+	yBytes := priv.PublicKey.Y.FillBytes(make([]byte, 32))
+	pub := append([]byte{0x04}, append(xBytes, yBytes...)...)
 
 	var pubKey [MaxPubKeyLen]byte
 	copy(pubKey[:], pub)


### PR DESCRIPTION
```
pub := append([]byte{0x04}, priv.PublicKey.X.Bytes()...)
pub = append(pub, priv.PublicKey.Y.Bytes()...)
```

`(*big.Int).Bytes()` returns the shortest-possible big-endian representation of the integer. If the most-significant byte happens to be 0x00, that byte is omitted.
